### PR TITLE
removed wcbmedia.io:8000 from arch list

### DIFF
--- a/arch.txt
+++ b/arch.txt
@@ -403,7 +403,6 @@ syd.mirror.rackspace.com
 tux.rainside.sk
 uvermont.mm.fcix.net
 vpsmurah.jagoanhosting.com
-wcbmedia.io:8000
 www.caco.ic.unicamp.br
 www.gtlib.gatech.edu
 www.gutscheindrache.com


### PR DESCRIPTION
A port number made it into the arch list of domains. Removed as I don't think it should be there.

Sam

